### PR TITLE
Add if_any option to map field

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -28,3 +28,4 @@ jobs:
         run: mix deps.get
       - name: Run tests
         run: mix coveralls
+        

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -1,6 +1,10 @@
 name: Elixir CI
 
-on: push
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   coveralls:
@@ -14,10 +18,13 @@ jobs:
       MIX_ENV: test
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v1.0.0
-      - uses: actions/setup-elixir@v1.0.0
+      - uses: actions/checkout@v2
+      - name: Setup elixir
+        uses: actions/setup-elixir@v1
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
-      - run: mix deps.get
-      - run: mix coveralls.github
+      - name: Install dependencies
+        run: mix deps.get
+      - name: Run tests
+        run: mix coveralls

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -28,4 +28,3 @@ jobs:
         run: mix deps.get
       - name: Run tests
         run: mix coveralls
-        

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![hex.pm](https://img.shields.io/hexpm/dt/talos.svg)](https://hex.pm/packages/talos)
 [![hex.pm](https://img.shields.io/hexpm/l/talos.svg)](https://hex.pm/packages/talos)
 [![github.com](https://img.shields.io/github/last-commit/balance-platform/talos.svg)](https://github.com/balance-platform/talos/commits/master)
+![Elixir CI](https://github.com/balance-platform/talos/workflows/Elixir%20CI/badge.svg)
 
 Talos is simple parameters validation library
 

--- a/lib/types/map_type.ex
+++ b/lib/types/map_type.ex
@@ -83,19 +83,20 @@ defmodule Talos.Types.MapType do
     end
   end
 
-  def errors(%__MODULE__{fields: fields, required_groups: list, allow_blank: false}, map) when is_list(list) do
+  def errors(%__MODULE__{fields: fields, required_groups: list, allow_blank: false}, map)
+      when is_list(list) do
     keys = Map.keys(map)
 
     if Enum.empty?(keys) do
-        ["one of keys should exist"]
+      ["one of keys should exist"]
     else
-        # проверить поля из required_groups
-        list
-        |> Enum.filter(fn key -> Enum.member?(keys, key) end)
-        |> Enum.map(fn key -> Enum.find(fields, &(&1.key == key)) end)
-        |> Enum.map(fn field -> field_errors(field, map) end)
-        |> Enum.reject(fn {_key, errors} -> errors == [] || errors == %{} end)
-        |> Map.new()
+      # проверить поля из required_groups
+      list
+      |> Enum.filter(fn key -> Enum.member?(keys, key) end)
+      |> Enum.map(fn key -> Enum.find(fields, &(&1.key == key)) end)
+      |> Enum.map(fn field -> field_errors(field, map) end)
+      |> Enum.reject(fn {_key, errors} -> errors == [] || errors == %{} end)
+      |> Map.new()
     end
   end
 

--- a/lib/types/map_type.ex
+++ b/lib/types/map_type.ex
@@ -116,7 +116,11 @@ defmodule Talos.Types.MapType do
         ["one of keys should exist"]
 
       any_one == true && has_values(map) ->
-        %{}
+        keys
+        |> Enum.map(fn key -> Enum.find(fields, &(&1.key == key)) end)
+        |> Enum.map(fn field -> field_errors(field, map) end)
+        |> Enum.reject(fn {_key, errors} -> errors == [] || errors == %{} end)
+        |> Map.new()
 
       is_list(groups) && Enum.empty?(groups) ->
         ["list should have value"]

--- a/lib/types/map_type/field.ex
+++ b/lib/types/map_type/field.ex
@@ -9,9 +9,9 @@ defmodule Talos.Types.MapType.Field do
     :type,
     :description,
     :default_value,
+    depends_on: nil,
     example_value: nil,
-    optional: false,
-    if_any: false
+    optional: false
   ]
 
   @type t :: %{
@@ -20,9 +20,9 @@ defmodule Talos.Types.MapType.Field do
           type: any,
           description: String.t(),
           default_value: any,
+          depends_on: list(),
           example_value: any,
-          optional: boolean,
-          if_any: boolean
+          optional: boolean
         }
 
   def valid?(%__MODULE__{} = field, expected_map_value)
@@ -32,27 +32,10 @@ defmodule Talos.Types.MapType.Field do
     errors in [%{}, []]
   end
 
-  def errors(%__MODULE__{if_any: true} = field, expected_map_value) do
-    keys = Map.keys(expected_map_value)
-    is_key_missed = !Map.has_key?(expected_map_value, field.key)
-    empty_values = Enum.all?(expected_map_value, fn {_k, value} -> is_nil(value) end)
-
-    cond do
-      Enum.empty?(keys) ->
-        {field.key, ["one of keys should exist"]}
-
-      is_key_missed && !empty_values ->
-        {field.key, []}
-
-      !is_key_missed && is_nil(expected_map_value[field.key]) && !empty_values ->
-        {field.key, []}
-
-      true ->
-        {field.key, Talos.errors(field.type, expected_map_value[field.key])}
-    end
-  end
-
-  def errors(%__MODULE__{if_any: false, optional: is_optional} = field, expected_map_value)
+  def errors(
+        %__MODULE__{depends_on: nil, optional: is_optional} = field,
+        expected_map_value
+      )
       when is_map(expected_map_value) do
     is_key_missed = !Map.has_key?(expected_map_value, field.key)
 
@@ -60,6 +43,29 @@ defmodule Talos.Types.MapType.Field do
       is_key_missed && !is_optional -> {field.key, ["should exist"]}
       is_key_missed && is_optional -> {field.key, []}
       true -> {field.key, Talos.errors(field.type, expected_map_value[field.key])}
+    end
+  end
+
+  def errors(
+        %__MODULE__{depends_on: deps, optional: is_optional} = field,
+        expected_map_value
+      )
+      when is_list(deps) do
+    is_key_missed = !Map.has_key?(expected_map_value, field.key)
+    all_dependencies = Enum.all?(deps, fn key -> Map.has_key?(expected_map_value, key) end)
+
+    cond do
+      is_key_missed && !is_optional ->
+        {field.key, ["should exist"]}
+
+      is_key_missed && is_optional ->
+        {field.key, []}
+
+      !is_key_missed && !all_dependencies ->
+        {field.key, ["all dependens_on fields should exist"]}
+
+      true ->
+        {field.key, Talos.errors(field.type, expected_map_value[field.key])}
     end
   end
 end

--- a/lib/types/map_type/field.ex
+++ b/lib/types/map_type/field.ex
@@ -4,7 +4,15 @@ defmodule Talos.Types.MapType.Field do
   # Belongs mostly to MapType, and used for key-value pairs
 
   @enforce_keys [:key, :type]
-  defstruct [:key, :type, :description, :default_value, example_value: nil, optional: false]
+  defstruct [
+    :key,
+    :type,
+    :description,
+    :default_value,
+    example_value: nil,
+    optional: false,
+    if_any: false
+  ]
 
   @type t :: %{
           __struct__: atom,
@@ -13,7 +21,8 @@ defmodule Talos.Types.MapType.Field do
           description: String.t(),
           default_value: any,
           example_value: any,
-          optional: boolean
+          optional: boolean,
+          if_any: boolean
         }
 
   def valid?(%__MODULE__{} = field, expected_map_value)
@@ -23,7 +32,27 @@ defmodule Talos.Types.MapType.Field do
     errors in [%{}, []]
   end
 
-  def errors(%__MODULE__{optional: is_optional} = field, expected_map_value)
+  def errors(%__MODULE__{if_any: true} = field, expected_map_value) do
+    keys = Map.keys(expected_map_value)
+    is_key_missed = !Map.has_key?(expected_map_value, field.key)
+    empty_values = Enum.all?(expected_map_value, fn {_k, value} -> is_nil(value) end)
+
+    cond do
+      Enum.empty?(keys) ->
+        {field.key, ["one of keys should exist"]}
+
+      is_key_missed && !empty_values ->
+        {field.key, []}
+
+      !is_key_missed && is_nil(expected_map_value[field.key]) && !empty_values ->
+        {field.key, []}
+
+      true ->
+        {field.key, Talos.errors(field.type, expected_map_value[field.key])}
+    end
+  end
+
+  def errors(%__MODULE__{if_any: false, optional: is_optional} = field, expected_map_value)
       when is_map(expected_map_value) do
     is_key_missed = !Map.has_key?(expected_map_value, field.key)
 

--- a/lib/types/string_type.ex
+++ b/lib/types/string_type.ex
@@ -56,6 +56,10 @@ defmodule Talos.Types.StringType do
     []
   end
 
+  def errors(%__MODULE__{allow_blank: false}, "") do
+    ["can not be blank"]
+  end
+
   def errors(%__MODULE__{allow_nil: true}, nil) do
     []
   end

--- a/test/types/map_type_test.exs
+++ b/test/types/map_type_test.exs
@@ -111,4 +111,36 @@ defmodule Talos.Types.MapTypeTest do
     assert %{} == MapType.errors(schema, %{"age" => nil, "name" => nil})
     assert %{} == MapType.errors(schema, %{"age" => nil, "name" => "Dmitry"})
   end
+
+  test "#errors - with required one of many fields" do
+    schema =
+      map(
+        fields: [
+          field(key: "name", type: string(), if_any: true),
+          field(key: "age", type: integer(gteq: 18), if_any: true)
+        ]
+      )
+
+    assert %{"age" => ["one of keys should exist"], "name" => ["one of keys should exist"]} =
+             MapType.errors(schema, %{})
+
+    assert %{
+             "name" => _error_message
+           } = MapType.errors(schema, %{"age" => nil})
+
+    assert %{
+             "name" => ["nil", "should be StringType"],
+             "age" => ["nil", "should be integer type"]
+           } ==
+             MapType.errors(schema, %{"age" => nil, "name" => nil})
+
+    assert %{
+             "name" => ["nil", "should be StringType"],
+             "age" => ["nil", "should be integer type"]
+           } == MapType.errors(schema, %{"name" => nil})
+
+    assert %{} == MapType.errors(schema, %{"age" => 18, "name" => "Dmitry"})
+    assert %{} == MapType.errors(schema, %{"name" => "Dmitry"})
+    assert %{} == MapType.errors(schema, %{"name" => nil, "age" => 21})
+  end
 end

--- a/test/types/map_type_test.exs
+++ b/test/types/map_type_test.exs
@@ -11,7 +11,7 @@ defmodule Talos.Types.MapTypeTest do
     assert false == MapType.valid?(map(), "e")
     assert false == MapType.valid?(map(), "z")
     assert true == MapType.valid?(map(allow_nil: true), nil)
-    assert true == MapType.valid?(map(), %{})
+    assert true == MapType.valid?(map(allow_blank: true), %{})
     assert true == MapType.valid?(map(), %{a: 3, b: 4})
   end
 
@@ -33,7 +33,7 @@ defmodule Talos.Types.MapTypeTest do
     assert ["0", _error_message] = MapType.errors(map(), 0)
     assert ["\"e\"", _error_message] = MapType.errors(map(), "e")
     assert ["\"z\"", _error_message] = MapType.errors(map(), "z")
-    assert %{} == MapType.errors(map(), %{})
+    assert %{} == MapType.errors(map(allow_blank: true), %{})
     assert %{} == MapType.errors(map(), %{a: 3, b: 4})
   end
 
@@ -160,23 +160,23 @@ defmodule Talos.Types.MapTypeTest do
              "middlename" => ["should exist"]
            } ==
              MapType.errors(schema, %{
-               "lastname" => "Лорка",
-               "firstname" => "Федерико"
+               "lastname" => "Lorca",
+               "firstname" => "Federico"
              })
 
     assert %{"firstname" => ["nil", "should be StringType"], "lastname" => ["can not be blank"]} ==
              MapType.errors(schema, %{
                "lastname" => "",
                "firstname" => nil,
-               "middlename" => "Гарсия",
+               "middlename" => "Garcia",
                "birthdate" => "1898-06-05"
              })
 
     assert %{} ==
              MapType.errors(schema, %{
-               "lastname" => "Лорка",
-               "firstname" => "Федерико",
-               "middlename" => "Гарсия",
+               "lastname" => "Lorca",
+               "firstname" => "Federico",
+               "middlename" => "Garcia",
                "birthdate" => "1898-06-05"
              })
   end
@@ -211,7 +211,13 @@ defmodule Talos.Types.MapTypeTest do
         ]
       )
 
-    assert ["one of keys should exist"] = MapType.errors(schema, %{})
+    assert %{
+             "birthdate" => ["should exist"],
+             "firstname" => ["should exist"],
+             "inn" => ["should exist"],
+             "lastname" => ["should exist"]
+           } = MapType.errors(schema, %{})
+
     assert %{} == MapType.errors(schema, %{"inn" => "3015081111"})
 
     assert %{
@@ -224,8 +230,8 @@ defmodule Talos.Types.MapTypeTest do
            } ==
              MapType.errors(schema, %{
                "inn" => "3015081111",
-               "lastname" => "Лорка",
-               "firstname" => "Федерико"
+               "lastname" => "Lorca",
+               "firstname" => "Federico"
              })
 
     assert %{
@@ -233,30 +239,30 @@ defmodule Talos.Types.MapTypeTest do
              "lastname" => ["all dependens_on fields should exist"]
            } ==
              MapType.errors(schema, %{
-               "lastname" => "Лорка",
-               "firstname" => "Федерико"
+               "lastname" => "Lorca",
+               "firstname" => "Federico"
              })
 
     assert %{"firstname" => ["nil", "should be StringType"], "lastname" => ["can not be blank"]} ==
              MapType.errors(schema, %{
                "lastname" => "",
                "firstname" => nil,
-               "middlename" => "Гарсия",
+               "middlename" => "Garcia",
                "birthdate" => "1898-06-05"
              })
 
     assert %{} ==
              MapType.errors(schema, %{
-               "lastname" => "Лорка",
-               "firstname" => "Федерико",
-               "middlename" => "Гарсия",
+               "lastname" => "Lorca",
+               "firstname" => "Federico",
+               "middlename" => "Garcia",
                "birthdate" => "1898-06-05"
              })
 
     assert %{} ==
              MapType.errors(schema, %{
-               "lastname" => "Лорка",
-               "firstname" => "Федерико",
+               "lastname" => "Lorca",
+               "firstname" => "Federico",
                "birthdate" => "1898-06-05"
              })
   end

--- a/test/types/map_type_test.exs
+++ b/test/types/map_type_test.exs
@@ -229,13 +229,13 @@ defmodule Talos.Types.MapTypeTest do
              })
 
     assert %{
-              "firstname" => ["all dependens_on fields should exist"],
-              "lastname" => ["all dependens_on fields should exist"]
-            } ==
-              MapType.errors(schema, %{
-                "lastname" => "Лорка",
-                "firstname" => "Федерико"
-              })
+             "firstname" => ["all dependens_on fields should exist"],
+             "lastname" => ["all dependens_on fields should exist"]
+           } ==
+             MapType.errors(schema, %{
+               "lastname" => "Лорка",
+               "firstname" => "Федерико"
+             })
 
     assert %{"firstname" => ["nil", "should be StringType"], "lastname" => ["can not be blank"]} ==
              MapType.errors(schema, %{

--- a/test/types/map_type_test.exs
+++ b/test/types/map_type_test.exs
@@ -151,7 +151,7 @@ defmodule Talos.Types.MapTypeTest do
              "lastname" => ["should exist"],
              "middlename" => ["should exist"],
              "birthdate" => ["all dependens_on fields should exist"]
-           } == MapType.errors(schema, %{"birthdate" => "1991-12-23"})
+           } == MapType.errors(schema, %{"birthdate" => "1898-06-05"})
 
     assert %{
              "birthdate" => ["should exist"],
@@ -160,30 +160,31 @@ defmodule Talos.Types.MapTypeTest do
              "middlename" => ["should exist"]
            } ==
              MapType.errors(schema, %{
-               "lastname" => "Минаев",
-               "firstname" => "Константин"
+               "lastname" => "Лорка",
+               "firstname" => "Федерико"
              })
 
     assert %{"firstname" => ["nil", "should be StringType"], "lastname" => ["can not be blank"]} ==
              MapType.errors(schema, %{
                "lastname" => "",
                "firstname" => nil,
-               "middlename" => "Геннадьевич",
-               "birthdate" => "1991-12-23"
+               "middlename" => "Гарсия",
+               "birthdate" => "1898-06-05"
              })
 
     assert %{} ==
              MapType.errors(schema, %{
-               "lastname" => "Минаев",
-               "firstname" => "Константин",
-               "middlename" => "Геннадьевич",
-               "birthdate" => "1991-12-23"
+               "lastname" => "Лорка",
+               "firstname" => "Федерико",
+               "middlename" => "Гарсия",
+               "birthdate" => "1898-06-05"
              })
   end
 
   test "@errors - depends_on, fio + birthdate with optional middlename" do
     schema =
       map(
+        required_groups: ["inn", "lastname", "firstname", "birthdate"],
         fields: [
           field(
             key: "lastname",
@@ -205,53 +206,58 @@ defmodule Talos.Types.MapTypeTest do
             key: "birthdate",
             type: string(),
             depends_on: ["lastname", "firstname"]
-          )
+          ),
+          field(key: "inn", type: string())
         ]
       )
 
-    assert %{
-             "firstname" => ["should exist"],
-             "lastname" => ["should exist"],
-             "birthdate" => ["should exist"]
-           } = MapType.errors(schema, %{})
+    assert ["one of keys should exist"] = MapType.errors(schema, %{})
+    assert %{} == MapType.errors(schema, %{"inn" => "3015081111"})
 
     assert %{
-             "firstname" => ["should exist"],
-             "lastname" => ["should exist"],
              "birthdate" => ["all dependens_on fields should exist"]
-           } == MapType.errors(schema, %{"birthdate" => "1991-12-23"})
+           } == MapType.errors(schema, %{"birthdate" => "1898-06-05"})
 
     assert %{
-             "birthdate" => ["should exist"],
              "firstname" => ["all dependens_on fields should exist"],
              "lastname" => ["all dependens_on fields should exist"]
            } ==
              MapType.errors(schema, %{
-               "lastname" => "Минаев",
-               "firstname" => "Константин"
+               "inn" => "3015081111",
+               "lastname" => "Лорка",
+               "firstname" => "Федерико"
              })
+
+    assert %{
+              "firstname" => ["all dependens_on fields should exist"],
+              "lastname" => ["all dependens_on fields should exist"]
+            } ==
+              MapType.errors(schema, %{
+                "lastname" => "Лорка",
+                "firstname" => "Федерико"
+              })
 
     assert %{"firstname" => ["nil", "should be StringType"], "lastname" => ["can not be blank"]} ==
              MapType.errors(schema, %{
                "lastname" => "",
                "firstname" => nil,
-               "middlename" => "Геннадьевич",
-               "birthdate" => "1991-12-23"
+               "middlename" => "Гарсия",
+               "birthdate" => "1898-06-05"
              })
 
     assert %{} ==
              MapType.errors(schema, %{
-               "lastname" => "Минаев",
-               "firstname" => "Константин",
-               "middlename" => "Геннадьевич",
-               "birthdate" => "1991-12-23"
+               "lastname" => "Лорка",
+               "firstname" => "Федерико",
+               "middlename" => "Гарсия",
+               "birthdate" => "1898-06-05"
              })
 
     assert %{} ==
              MapType.errors(schema, %{
-               "lastname" => "Минаев",
-               "firstname" => "Константин",
-               "birthdate" => "1991-12-23"
+               "lastname" => "Лорка",
+               "firstname" => "Федерико",
+               "birthdate" => "1898-06-05"
              })
   end
 

--- a/test/types/string_type_test.exs
+++ b/test/types/string_type_test.exs
@@ -17,6 +17,7 @@ defmodule Talos.Types.StringTypeTest do
 
   test "#valid? with allow_blank" do
     assert true == StringType.valid?(%StringType{allow_blank: true, min_length: 30}, "")
+    assert false == StringType.valid?(%StringType{}, "")
   end
 
   test "#valid? - without regexp" do
@@ -36,7 +37,7 @@ defmodule Talos.Types.StringTypeTest do
     assert false == StringType.valid?(%StringType{max_length: 3}, "String")
     assert true == StringType.valid?(%StringType{min_length: 3}, "String")
     assert false == StringType.valid?(%StringType{min_length: 3}, "")
-    assert true == StringType.valid?(%StringType{min_length: 0}, "")
+    assert true == StringType.valid?(%StringType{min_length: 0, allow_blank: true}, "")
   end
 
   test "#errors - other params" do
@@ -50,7 +51,7 @@ defmodule Talos.Types.StringTypeTest do
              StringType.errors(%StringType{max_length: 3}, "String")
 
     assert [] == StringType.errors(%StringType{min_length: 3}, "String")
-    assert ["\"\"", _error_message] = StringType.errors(%StringType{min_length: 3}, "")
-    assert [] == StringType.errors(%StringType{min_length: 0}, "")
+    assert ["can not be blank"] = StringType.errors(%StringType{min_length: 3}, "")
+    assert [] == StringType.errors(%StringType{min_length: 0, allow_blank: true}, "")
   end
 end


### PR DESCRIPTION
В структуру `Talos.Types.MapType.Field` добавлен ключ `depends_on: list`
В `Talos.Types.MapType` добавлено два ключа:
*   `required_any_one: boolean()`
*   `required_groups: list()`

Ожидаемое поведение: 
 - если `depends_on: list(type: string)` то поле будет считаться валидным, только если оно валидно само и все указанные в зависимостях ключи тоже валидны 
 - `required_any_one: true` должно быть валидное хотя бы одно поле в структуре
 - `required_groups: ["key1", "key2"]` должна быть валидна хотя бы одна группа из списка. Ключ может указывать на простое поле, а может на поле с depends_on, тогда валидация пойдёт проверять все зависимые поля. Валидно может быть либо простое поле, либо вся группа.  