### PR TITLE
Fix string type errors function

### DIFF
--- a/lib/types/string_type.ex
+++ b/lib/types/string_type.ex
@@ -69,7 +69,7 @@ defmodule Talos.Types.StringType do
         value
       ) do
     errors =
-      case String.valid?(value) do
+      case is_binary(value) && String.valid?(value) do
         true ->
           str_len = String.length(value)
 


### PR DESCRIPTION
Added an additional check `is_binary` before `String.valid?`, because since [version 15 of Elixir](https://github.com/elixir-lang/elixir/blob/v1.15.0/lib/elixir/lib/string.ex#L1828), the function String.valid? only accepts strings, otherwise we get an error

```
    ** (FunctionClauseError) no function clause matching in String.valid?/2

     The following arguments were given to String.valid?/2:

         # 1
         1.0

         # 2
         :default

     Attempted function clauses (showing 2 out of 2):

         def valid?(<<string::binary>>, :default)
         def valid?(<<string::binary>>, :fast_ascii)
```